### PR TITLE
Fix imports and update test

### DIFF
--- a/streamlit_conciliacao/app.py
+++ b/streamlit_conciliacao/app.py
@@ -9,7 +9,11 @@ from typing import Any, Dict
 import pandas as pd
 import streamlit as st
 
-from .utils import get_logger, read_extrato, read_lancamentos
+from streamlit_conciliacao.utils import (
+    get_logger,
+    read_extrato,
+    read_lancamentos,
+)
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 LOGGER = get_logger()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,7 @@ from streamlit_conciliacao import utils_git
 
 
 def test_leitura_e_csv(tmp_path: Path) -> None:
-    df = pd.DataFrame({"A": [1, 2]})
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     excel_path = tmp_path / "dados.xlsx"
     with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
         df.to_excel(writer, index=False)


### PR DESCRIPTION
## Summary
- use absolute import path for Streamlit utils
- adjust utils test to avoid delimiter mismatch on newer pandas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f91733c48326b736b545f2f883f3