### PR TITLE
Fix imports and clean style

### DIFF
--- a/streamlit_conciliacao/app.py
+++ b/streamlit_conciliacao/app.py
@@ -9,7 +9,11 @@ from typing import Any, Dict
 import pandas as pd
 import streamlit as st
 
-from .utils import get_logger, read_extrato, read_lancamentos
+from streamlit_conciliacao.utils import (
+    get_logger,
+    read_extrato,
+    read_lancamentos,
+)
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 LOGGER = get_logger()
@@ -54,7 +58,10 @@ def main() -> None:
         st.json(config)
 
     extrato_file = st.file_uploader("Extrato Bancário (.xlsx)", type=["xlsx"])
-    lanc_file = st.file_uploader("Planilha de Lançamentos (.xlsx)", type=["xlsx"])
+    lanc_file = st.file_uploader(
+        "Planilha de Lançamentos (.xlsx)",
+        type=["xlsx"],
+    )
 
     if extrato_file is not None:
         try:

--- a/streamlit_conciliacao/utils_git.py
+++ b/streamlit_conciliacao/utils_git.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+
 
 from github import Github
 
 
-def commit_json(token: str, repo: str, rel_path: str, data: dict, msg: str) -> None:
+def commit_json(
+    token: str,
+    repo: str,
+    rel_path: str,
+    data: dict,
+    msg: str,
+) -> None:
     """Cria ou atualiza arquivo JSON em um repositório GitHub.
 
     A função só executa quando ``token`` e ``repo`` são informados.
@@ -22,7 +28,11 @@ def commit_json(token: str, repo: str, rel_path: str, data: dict, msg: str) -> N
     content = json.dumps(data, indent=2, ensure_ascii=False)
     try:
         existing = repository.get_contents(rel_path)
-        repository.update_file(existing.path, msg, content, existing.sha)
+        repository.update_file(
+            existing.path,
+            msg,
+            content,
+            existing.sha,
+        )
     except Exception:
         repository.create_file(rel_path, msg, content)
-

--- a/tests/test_cadastro.py
+++ b/tests/test_cadastro.py
@@ -1,11 +1,10 @@
-import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from streamlit_conciliacao import cadastro
+from streamlit_conciliacao import cadastro  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,16 @@
-import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
-import pytest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from streamlit_conciliacao import utils
-from streamlit_conciliacao import utils_git
+import pandas as pd  # noqa: E402
+from streamlit_conciliacao import utils  # noqa: E402
+from streamlit_conciliacao import utils_git  # noqa: E402
 
 
 def test_leitura_e_csv(tmp_path: Path) -> None:
-    df = pd.DataFrame({"A": [1, 2]})
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     excel_path = tmp_path / "dados.xlsx"
     with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
         df.to_excel(writer, index=False)
@@ -34,7 +34,10 @@ def test_commit_json(monkeypatch):
     github_instance = MagicMock()
     github_instance.get_repo.return_value = repo_mock
 
-    with patch("streamlit_conciliacao.utils_git.Github", return_value=github_instance) as gh_cls:
+    with patch(
+        "streamlit_conciliacao.utils_git.Github",
+        return_value=github_instance,
+    ) as gh_cls:
         repo_mock.get_contents.return_value = file_mock
         utils_git.commit_json("t", "org/repo", "p.json", {"x": 1}, "msg")
         repo_mock.update_file.assert_called_once()
@@ -49,4 +52,3 @@ def test_commit_json(monkeypatch):
     with patch("streamlit_conciliacao.utils_git.Github") as gh_cls:
         utils_git.commit_json("", "", "a.json", {}, "msg")
         gh_cls.assert_not_called()
-


### PR DESCRIPTION
## Summary
- maintain multi-line file uploader for Streamlit
- expand Github helper for readability
- tidy tests and suppress flake8 warnings

## Testing
- `flake8 streamlit_conciliacao tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878f91733c48326b736b545f2f883f3