### PR TITLE
Implement conciliador

### DIFF
--- a/streamlit_conciliacao/app.py
+++ b/streamlit_conciliacao/app.py
@@ -9,7 +9,11 @@ from typing import Any, Dict
 import pandas as pd
 import streamlit as st
 
-from .utils import get_logger, read_extrato, read_lancamentos
+from streamlit_conciliacao.utils import (
+    get_logger,
+    read_extrato,
+    read_lancamentos,
+)
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 LOGGER = get_logger()
@@ -54,7 +58,10 @@ def main() -> None:
         st.json(config)
 
     extrato_file = st.file_uploader("Extrato Bancário (.xlsx)", type=["xlsx"])
-    lanc_file = st.file_uploader("Planilha de Lançamentos (.xlsx)", type=["xlsx"])
+    lanc_file = st.file_uploader(
+        "Planilha de Lançamentos (.xlsx)",
+        type=["xlsx"],
+    )
 
     if extrato_file is not None:
         try:

--- a/streamlit_conciliacao/conciliador.py
+++ b/streamlit_conciliacao/conciliador.py
@@ -1,3 +1,236 @@
-"""Módulo responsável pela lógica de conciliação."""
+"""Funcoes de conciliacao de extrato bancario com lancamentos."""
 
-pass
+from __future__ import annotations
+
+from typing import Any, List
+
+import pandas as pd
+
+# Constantes padrao
+CONTA_FORNECEDOR_PADRAO = 5
+CONTA_CAIXA = 5
+COD_HISTORICO_PAGAMENTO = 34
+COD_HISTORICO_PAG_CAIXA = 1
+COD_HISTORICO_DEPOSITO = 9
+
+
+def _parse_valor_extrato(valor: Any) -> tuple[float, str]:
+    """Converte valor do extrato (ex: '123,00D') para (float, tipo)."""
+    s = str(valor).strip()
+    tipo = s[-1].upper()
+    numero = s[:-1].replace('.', '').replace(',', '.')
+    return float(numero), tipo
+
+
+def _parse_valor(valor: Any) -> float:
+    """Converte valor no formato brasileiro para float."""
+    s = str(valor).strip()
+    if not s:
+        return 0.0
+    return float(s.replace('.', '').replace(',', '.'))
+
+
+def _fmt_valor(valor: float) -> str:
+    """Formata valor float para string no formato '123,45'."""
+    txt = format(valor, ',.2f')
+    return txt.replace(',', 'X').replace('.', ',').replace('X', '.')
+
+
+def _fmt_data(data: Any) -> str:
+    """Formata data para 'dd/mm/aaaa'."""
+    return pd.to_datetime(data, dayfirst=True).strftime('%d/%m/%Y')
+
+
+def _get_primeira_conta(contas: dict) -> int:
+    """Retorna o primeiro codigo de conta de um dicionario."""
+    if not contas:
+        return 0
+    return next(iter(contas.values()))
+
+
+def _add_lote(rows: List[dict]) -> None:
+    """Se 'rows' tem mais de uma linha, marca a primeira com 'Inicia Lote'."""
+    if len(rows) > 1:
+        rows[0]['Inicia Lote'] = '1'
+
+
+def conciliar(
+    df_extrato: pd.DataFrame,
+    df_lancamentos: pd.DataFrame,
+    config: dict,
+) -> pd.DataFrame:
+    """Concilia saidas do extrato com lancamentos."""
+
+    banco_conta = _get_primeira_conta(config.get('contas_pagamento', {}))
+    conta_multa = config.get('multas_juros', 0)
+    conta_desconto = config.get('descontos', 0)
+    conta_tarifa = config.get('tarifas', 316)
+
+    lancamentos = df_lancamentos.copy()
+    lancamentos['_valor'] = lancamentos['Valor a pagar'].apply(_parse_valor)
+    lancamentos['_multa'] = lancamentos['Multa e juros'].apply(_parse_valor)
+    lancamentos['_desconto'] = lancamentos['Descontos'].apply(_parse_valor)
+    lancamentos['_tarifa'] = lancamentos[
+        'Tarifas de Boleto'
+    ].apply(_parse_valor)
+    lancamentos['_data'] = lancamentos['Data pagamento'].apply(_fmt_data)
+    lancamentos['_matched'] = False
+
+    resultado: List[dict] = []
+
+    for _, row in df_extrato.iterrows():
+        valor, tipo = _parse_valor_extrato(row['Valor'])
+        data = _fmt_data(row['Data'])
+
+        if tipo != 'D':
+            continue
+
+        possiveis = lancamentos[
+            (lancamentos['_data'] == data)
+            & (lancamentos['_valor'] == valor)
+            & (~lancamentos['_matched'])
+        ]
+        if not possiveis.empty:
+            idx = possiveis.index[0]
+            lanc_row = lancamentos.loc[idx]
+            lancamentos.at[idx, '_matched'] = True
+
+            fornecedor = lanc_row['Nome do fornecedor']
+            nota = lanc_row['Nota fiscal']
+            codigo_forn = config.get('fornecedores', {}).get(
+                fornecedor, CONTA_FORNECEDOR_PADRAO
+            )
+            complemento = f"{nota} {fornecedor}".strip()
+
+            linhas = [
+                {
+                    'Data': data,
+                    'Cod Conta Débito': codigo_forn,
+                    'Cod Conta Crédito': banco_conta,
+                    'Valor': _fmt_valor(valor),
+                    'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                    'Complemento': complemento,
+                    'Inicia Lote': '',
+                }
+            ]
+            if lanc_row['_multa'] > 0:
+                linhas.append(
+                    {
+                        'Data': data,
+                        'Cod Conta Débito': conta_multa,
+                        'Cod Conta Crédito': '',
+                        'Valor': _fmt_valor(lanc_row['_multa']),
+                        'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                        'Complemento': complemento,
+                        'Inicia Lote': '',
+                    }
+                )
+            if lanc_row['_desconto'] > 0:
+                linhas.append(
+                    {
+                        'Data': data,
+                        'Cod Conta Débito': '',
+                        'Cod Conta Crédito': conta_desconto,
+                        'Valor': _fmt_valor(lanc_row['_desconto']),
+                        'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                        'Complemento': complemento,
+                        'Inicia Lote': '',
+                    }
+                )
+            if lanc_row['_tarifa'] > 0:
+                linhas.append(
+                    {
+                        'Data': data,
+                        'Cod Conta Débito': conta_tarifa,
+                        'Cod Conta Crédito': '',
+                        'Valor': _fmt_valor(lanc_row['_tarifa']),
+                        'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                        'Complemento': complemento,
+                        'Inicia Lote': '',
+                    }
+                )
+            _add_lote(linhas)
+            resultado.extend(linhas)
+        else:
+            resultado.append(
+                {
+                    'Data': data,
+                    'Cod Conta Débito': CONTA_FORNECEDOR_PADRAO,
+                    'Cod Conta Crédito': banco_conta,
+                    'Valor': _fmt_valor(valor),
+                    'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                    'Complemento': '',
+                    'Inicia Lote': '',
+                }
+            )
+
+    restantes = lancamentos[~lancamentos['_matched']]
+    for _, lanc_row in restantes.iterrows():
+        data = lanc_row['_data']
+        fornecedor = lanc_row['Nome do fornecedor']
+        nota = lanc_row['Nota fiscal']
+        codigo_forn = config.get('fornecedores', {}).get(
+            fornecedor, CONTA_FORNECEDOR_PADRAO
+        )
+        complemento = f"{nota} {fornecedor}".strip()
+
+        linhas = [
+            {
+                'Data': data,
+                'Cod Conta Débito': codigo_forn,
+                'Cod Conta Crédito': CONTA_CAIXA,
+                'Valor': _fmt_valor(lanc_row['_valor']),
+                'Cod Histórico': COD_HISTORICO_PAG_CAIXA,
+                'Complemento': complemento,
+                'Inicia Lote': '',
+            }
+        ]
+        if lanc_row['_multa'] > 0:
+            linhas.append(
+                {
+                    'Data': data,
+                    'Cod Conta Débito': conta_multa,
+                    'Cod Conta Crédito': '',
+                    'Valor': _fmt_valor(lanc_row['_multa']),
+                    'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                    'Complemento': complemento,
+                    'Inicia Lote': '',
+                }
+            )
+        if lanc_row['_desconto'] > 0:
+            linhas.append(
+                {
+                    'Data': data,
+                    'Cod Conta Débito': '',
+                    'Cod Conta Crédito': conta_desconto,
+                    'Valor': _fmt_valor(lanc_row['_desconto']),
+                    'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                    'Complemento': complemento,
+                    'Inicia Lote': '',
+                }
+            )
+        if lanc_row['_tarifa'] > 0:
+            linhas.append(
+                {
+                    'Data': data,
+                    'Cod Conta Débito': conta_tarifa,
+                    'Cod Conta Crédito': '',
+                    'Valor': _fmt_valor(lanc_row['_tarifa']),
+                    'Cod Histórico': COD_HISTORICO_PAGAMENTO,
+                    'Complemento': complemento,
+                    'Inicia Lote': '',
+                }
+            )
+        _add_lote(linhas)
+        resultado.extend(linhas)
+
+    cols = [
+        'Data',
+        'Cod Conta Débito',
+        'Cod Conta Crédito',
+        'Valor',
+        'Cod Histórico',
+        'Complemento',
+        'Inicia Lote',
+    ]
+    return pd.DataFrame(resultado, columns=cols)

--- a/streamlit_conciliacao/utils_git.py
+++ b/streamlit_conciliacao/utils_git.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+
 
 from github import Github
 
 
-def commit_json(token: str, repo: str, rel_path: str, data: dict, msg: str) -> None:
+def commit_json(
+    token: str,
+    repo: str,
+    rel_path: str,
+    data: dict,
+    msg: str,
+) -> None:
     """Cria ou atualiza arquivo JSON em um repositório GitHub.
 
     A função só executa quando ``token`` e ``repo`` são informados.
@@ -22,7 +28,11 @@ def commit_json(token: str, repo: str, rel_path: str, data: dict, msg: str) -> N
     content = json.dumps(data, indent=2, ensure_ascii=False)
     try:
         existing = repository.get_contents(rel_path)
-        repository.update_file(existing.path, msg, content, existing.sha)
+        repository.update_file(
+            existing.path,
+            msg,
+            content,
+            existing.sha,
+        )
     except Exception:
         repository.create_file(rel_path, msg, content)
-

--- a/tests/test_cadastro.py
+++ b/tests/test_cadastro.py
@@ -1,11 +1,10 @@
-import json
-from pathlib import Path
 import sys
+from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from streamlit_conciliacao import cadastro
+from streamlit_conciliacao import cadastro  # noqa: E402
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_conciliador.py
+++ b/tests/test_conciliador.py
@@ -1,0 +1,78 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from streamlit_conciliacao import conciliador  # noqa: E402
+
+
+def test_pagamento_conciliado():
+    df_extrato = pd.DataFrame(
+        {
+            'Data': ['01/01/2024'],
+            'Histórico': ['PAG'],
+            'Valor': ['100,00D'],
+        }
+    )
+    df_lanc = pd.DataFrame(
+        {
+            'Data pagamento': ['01/01/2024'],
+            'Nome do fornecedor': ['ACME'],
+            'Nota fiscal': ['123'],
+            'Valor': ['100,00'],
+            'Descontos': ['0,00'],
+            'Multa e juros': ['0,00'],
+            'Valor a pagar': ['100,00'],
+            'Tarifas de Boleto': ['0,00'],
+        }
+    )
+    config = {
+        'fornecedores': {'ACME': 10},
+        'contas_pagamento': {'Banco': 7},
+        'multas_juros': 50,
+        'descontos': 60,
+    }
+    result = conciliador.conciliar(df_extrato, df_lanc, config)
+    assert len(result) == 1
+    row = result.iloc[0]
+    assert row['Cod Conta Débito'] == 10
+    assert row['Cod Conta Crédito'] == 7
+    assert row['Valor'] == '100,00'
+    assert row['Cod Histórico'] == 34
+    assert row['Complemento'] == '123 ACME'
+
+
+def test_pagamento_caixa_restante():
+    df_extrato = pd.DataFrame(
+        {
+            'Data': ['01/01/2024'],
+            'Histórico': ['SAI'],
+            'Valor': ['100,00D'],
+        }
+    )
+    df_lanc = pd.DataFrame(
+        {
+            'Data pagamento': ['01/01/2024'],
+            'Nome do fornecedor': ['ACME'],
+            'Nota fiscal': ['123'],
+            'Valor': ['80,00'],
+            'Descontos': ['10,00'],
+            'Multa e juros': ['5,00'],
+            'Valor a pagar': ['75,00'],
+            'Tarifas de Boleto': ['2,00'],
+        }
+    )
+    config = {
+        'fornecedores': {'ACME': 10},
+        'contas_pagamento': {'Banco': 7},
+        'multas_juros': 50,
+        'descontos': 60,
+    }
+    result = conciliador.conciliar(df_extrato, df_lanc, config)
+    # primeira linha: extrato nao conciliado
+    assert result.iloc[0]['Cod Conta Débito'] == 5
+    # depois, quatro linhas do lancamento nao conciliado
+    assert result.iloc[1]['Cod Histórico'] == 1
+    assert result.iloc[1]['Inicia Lote'] == '1'
+    assert len(result) == 5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,16 +1,16 @@
-import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
-import pytest
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from streamlit_conciliacao import utils
-from streamlit_conciliacao import utils_git
+import pandas as pd  # noqa: E402
+from streamlit_conciliacao import utils  # noqa: E402
+from streamlit_conciliacao import utils_git  # noqa: E402
 
 
 def test_leitura_e_csv(tmp_path: Path) -> None:
-    df = pd.DataFrame({"A": [1, 2]})
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
     excel_path = tmp_path / "dados.xlsx"
     with pd.ExcelWriter(excel_path, engine="openpyxl") as writer:
         df.to_excel(writer, index=False)
@@ -34,7 +34,10 @@ def test_commit_json(monkeypatch):
     github_instance = MagicMock()
     github_instance.get_repo.return_value = repo_mock
 
-    with patch("streamlit_conciliacao.utils_git.Github", return_value=github_instance) as gh_cls:
+    with patch(
+        "streamlit_conciliacao.utils_git.Github",
+        return_value=github_instance,
+    ) as gh_cls:
         repo_mock.get_contents.return_value = file_mock
         utils_git.commit_json("t", "org/repo", "p.json", {"x": 1}, "msg")
         repo_mock.update_file.assert_called_once()
@@ -49,4 +52,3 @@ def test_commit_json(monkeypatch):
     with patch("streamlit_conciliacao.utils_git.Github") as gh_cls:
         utils_git.commit_json("", "", "a.json", {}, "msg")
         gh_cls.assert_not_called()
-


### PR DESCRIPTION
## Summary
- implement full matching logic in `conciliador`
- add unit tests covering matched and unmatched scenarios

## Testing
- `flake8 streamlit_conciliacao tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f91733c48326b736b545f2f883f3